### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/kdheepak/ratatui-statusbar/compare/v0.1.0...v0.2.0) - 2024-04-19
+
+### Added
+- Add release-plz.yml
+- clippy errors
+- Update CI
+- Update README
+- Update README
+- Add ci
+- Better test
+- Better api
+- Use impl Into<Line>
+- Using thiserror for better api
+- Remove clear
+- Use Line instead of String

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-statusbar"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Dheepak Krishnamurthy"]
 description = "A statusbar widget for ratatui"


### PR DESCRIPTION
## 🤖 New release
* `ratatui-statusbar`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `ratatui-statusbar` breaking changes

```
--- failure inherent_method_must_use_added: inherent method #[must_use] added ---

Description:
An inherent method is now #[must_use]. Downstream crates that did not use its return value will get a compiler lint.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/inherent_method_must_use_added.ron

Failed in:
  method ratatui_statusbar::StatusBar::new in /tmp/.tmpghtQOv/ratatui-statusbar/src/lib.rs:114

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/method_parameter_count_changed.ron

Failed in:
  ratatui_statusbar::StatusBar::new now takes 1 parameters instead of 0, in /tmp/.tmpghtQOv/ratatui-statusbar/src/lib.rs:114
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/kdheepak/ratatui-statusbar/compare/v0.1.0...v0.2.0) - 2024-04-19

### Added
- Add release-plz.yml
- clippy errors
- Update CI
- Update README
- Update README
- Add ci
- Better test
- Better api
- Use impl Into<Line>
- Using thiserror for better api
- Remove clear
- Use Line instead of String
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).