### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/kdheepak/ratatui-statusbar/compare/v0.2.0...v0.2.1) - 2024-04-19
+
+### Other
+- Update README.md
+
 ## [0.2.0](https://github.com/kdheepak/ratatui-statusbar/compare/v0.1.0...v0.2.0) - 2024-04-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-statusbar"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "color-eyre",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-statusbar"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Dheepak Krishnamurthy"]
 description = "A statusbar widget for ratatui"


### PR DESCRIPTION
## 🤖 New release
* `ratatui-statusbar`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/kdheepak/ratatui-statusbar/compare/v0.2.0...v0.2.1) - 2024-04-19

### Other
- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).